### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
         }
     ],
     "require": {
-        "php" : "^7.0",
-        "illuminate/support": "~5.3.0|~5.4.0",
+        "php": "^7.0",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev",
         "nesbot/carbon": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*",
-        "orchestra/testbench":"~3.3.0|~3.4.0"
+        "phpunit/phpunit": "^6.2",
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
         "nesbot/carbon": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",
-        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev"
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev|~3.5.x-dev"
     },
     "autoload": {
         "psr-4": {
@@ -51,3 +51,4 @@
         }
     }
 }
+


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-directory-cleanup/phpunit.xml.dist

.                                                                   1 / 1 (100%)

Time: 1.77 seconds, Memory: 14.00MB

OK (1 test, 25 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments