### PR TITLE
Add Laravel 5.6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     ],
     "require": {
         "php" : "^7.0",
-        "illuminate/support": "~5.3.0|~5.4.0",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.0|~5.6.0",
         "nesbot/carbon": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*",
-        "orchestra/testbench":"~3.3.0|~3.4.0"
+        "phpunit/phpunit": "^5.0|^6.0|^7.0",
+        "orchestra/testbench":"~3.3.0|~3.4.0|~3.5.0|~3.6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Thanks for tagging a new release before. Unfortunately the new release did not help us after all since we use Laravel 5.6 and the newly tagged release did no longer support that. This hopefully addresses that issue.