### PR TITLE
Add support for deleting files from sub directories

### DIFF
--- a/src/DirectoryCleaner.php
+++ b/src/DirectoryCleaner.php
@@ -43,7 +43,7 @@ class DirectoryCleaner
     {
         $timeInPast = Carbon::now()->subMinutes($minutes);
 
-        return collect($this->filesystem->files($this->directory))
+        return collect($this->filesystem->allFiles($this->directory))
             ->filter(function ($file) use ($timeInPast) {
                 return Carbon::createFromTimestamp(filemtime($file))
                     ->lt($timeInPast);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,14 +25,14 @@ class TestCase extends OrchestraTestCase
         if (File::isDirectory($directory)) {
             File::deleteDirectory($directory);
         }
-        File::makeDirectory($directory);
+        File::makeDirectory($directory, 0775, true);
 
-        file_put_contents($directory.'/.gitignore', '*'.PHP_EOL.'!.gitignore');
+        file_put_contents($directory . '/.gitignore', '*' . PHP_EOL . '!.gitignore');
     }
 
     protected function getTempDirectory($subDirectory = '', $createIfNotExists = false)
     {
-        $fullDirectoryName = __DIR__."/temp/{$subDirectory}";
+        $fullDirectoryName = __DIR__ . "/temp/{$subDirectory}";
 
         if ($createIfNotExists) {
             $this->initializeDirectory($fullDirectoryName);


### PR DESCRIPTION
Right now, by using `$this->filesystem->files()` only the files in the root of the directory are deleted. By changing this to `$this->filesystem->allFiles()` all files, even in sub directories will be selected.

I've added a test, which was largely based on the first test.