### PR TITLE
Updated plugin to use any filesystem (S3, local etc...)

### DIFF
--- a/src/DirectoryCleaner.php
+++ b/src/DirectoryCleaner.php
@@ -42,12 +42,11 @@ class DirectoryCleaner
      */
     public function setFileSystemDriver(string $driver)
     {
-
         $this->filesystem = Storage::disk($driver);
 
         return $this;
     }
-
+    
     /**
      * @param int $minutes
      *

--- a/src/DirectoryCleaner.php
+++ b/src/DirectoryCleaner.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Storage;
 
 class DirectoryCleaner
 {
-    /** @var \Illuminate\Support\Facades\Storage */
+    /** @var \Illuminate\Filesystem\Filesystem */
     protected $filesystem;
 
     /** @var string */
@@ -42,6 +42,7 @@ class DirectoryCleaner
      */
     public function setFileSystemDriver(string $driver)
     {
+
         $this->filesystem = Storage::disk($driver);
 
         return $this;
@@ -52,13 +53,14 @@ class DirectoryCleaner
      *
      * @return \Illuminate\Support\Collection
      */
-    public function deleteFilesOlderThanMinutes(int $minutes) : Collection
+    public function deleteFilesOlderThanMinutes(int $minutes): Collection
     {
         $timeInPast = Carbon::now()->subMinutes($minutes);
 
         return collect($this->filesystem->allFiles($this->directory))
             ->filter(function ($file) use ($timeInPast) {
-                return Carbon::createFromTimestamp($this->filesystem->lastModified($file))
+                return Carbon
+                    ::createFromTimestamp($this->filesystem->lastModified($file))
                     ->lt($timeInPast);
             })
             ->each(function ($file) {

--- a/src/DirectoryCleaner.php
+++ b/src/DirectoryCleaner.php
@@ -4,22 +4,22 @@ namespace Spatie\DirectoryCleanup;
 
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Storage;
 
 class DirectoryCleaner
 {
-    /** @var \Illuminate\Filesystem\Filesystem */
+    /** @var \Illuminate\Support\Facades\Storage */
     protected $filesystem;
 
     /** @var string */
     protected $directory;
 
     /**
-     * @param \Illuminate\Filesystem\Filesystem $filesystem
+     * DirectoryCleaner constructor.
      */
-    public function __construct(Filesystem $filesystem)
+    public function __construct()
     {
-        $this->filesystem = $filesystem;
+        $this->filesystem = Storage::disk();
     }
 
     /**
@@ -45,7 +45,7 @@ class DirectoryCleaner
 
         return collect($this->filesystem->allFiles($this->directory))
             ->filter(function ($file) use ($timeInPast) {
-                return Carbon::createFromTimestamp(filemtime($file))
+                return Carbon::createFromTimestamp($this->filesystem->lastModified($file))
                     ->lt($timeInPast);
             })
             ->each(function ($file) {

--- a/src/DirectoryCleaner.php
+++ b/src/DirectoryCleaner.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Storage;
 
 class DirectoryCleaner
 {
-    /** @var \Illuminate\Filesystem\Filesystem */
+    /** @var \Illuminate\Contracts\Filesystem\Filesystem */
     protected $filesystem;
 
     /** @var string */

--- a/src/DirectoryCleaner.php
+++ b/src/DirectoryCleaner.php
@@ -19,6 +19,7 @@ class DirectoryCleaner
      */
     public function __construct()
     {
+        // use our default storage by default
         $this->filesystem = Storage::disk();
     }
 
@@ -30,6 +31,18 @@ class DirectoryCleaner
     public function setDirectory(string $directory)
     {
         $this->directory = $directory;
+
+        return $this;
+    }
+
+    /**
+     * @param string $driver
+     *
+     * @return $this
+     */
+    public function setFileSystemDriver(string $driver)
+    {
+        $this->filesystem = Storage::disk($driver);
 
         return $this;
     }


### PR DESCRIPTION
I was looking for a plugin that was able to delete old files within a directory from my project which utilises S3 buckets. This project looked great but it just used the local Filesystem. With a few basic changes this package is now able to use S3, AWS, DO and many more (assuming the driver implements Laravel's Filesystem contracts).

All I've done is change the filesystem to load the default system disk, and added a new method `setFileSystemDriver` to be able to use this package with custom drivers. This could be expanded further so that a driver could be specified with every directory within the config file.