### PR TITLE
Add support for deleting empty subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,15 @@ return [
         /*
          * Here you can specify which directories need to be cleanup. All files older than
          * the specified amount of minutes will be deleted.
+         *
+         * If deleteEmptySubdirectories is set to a non empty value, empty subdirectories
+         * will be deleted.
          */
 
         /*
         'path/to/a/directory' => [
             'deleteAllOlderThanMinutes' => 60 * 24,
+            'deleteEmptySubdirectories' => true,
         ],
         */
     ],
@@ -67,6 +71,8 @@ return [
 Specify the directories that need cleaning in the config file.
 
 When running the console command `clean:directories` all files in the specified directories older then `deleteAllOlderThanMinutes` will be deleted.
+
+If `deleteEmptySubdirectories` is set to true empty subdirectories will be deleted.
 
 This command can be scheduled in Laravel's console kernel.
 

--- a/config/laravel-directory-cleanup.php
+++ b/config/laravel-directory-cleanup.php
@@ -7,11 +7,15 @@ return [
         /*
          * Here you can specify which directories need to be cleanup. All files older than
          * the specified amount of minutes will be deleted.
+         *
+         * If deleteEmptySubdirectories is set to a non empty value, empty subdirectories
+         * will be deleted.
          */
 
         /*
         'path/to/a/directory' => [
             'deleteAllOlderThanMinutes' => 60 * 24,
+            'deleteEmptySubdirectories' => true,
         ],
         */
     ],

--- a/src/DirectoryCleaner.php
+++ b/src/DirectoryCleaner.php
@@ -44,6 +44,17 @@ class DirectoryCleaner
             });
     }
 
+    public function deleteEmptySubdirectories() : Collection
+    {
+        return collect($this->filesystem->directories($this->directory))
+            ->filter(function ($directory) {
+                return !$this->filesystem->allFiles($directory);
+            })
+            ->each(function ($directory) {
+                $this->filesystem->deleteDirectory($directory);
+            });
+    }
+
     protected function policy() : CleanupPolicy
     {
         return resolve(config(

--- a/src/DirectoryCleaner.php
+++ b/src/DirectoryCleaner.php
@@ -48,7 +48,7 @@ class DirectoryCleaner
     {
         return collect($this->filesystem->directories($this->directory))
             ->filter(function ($directory) {
-                return !$this->filesystem->allFiles($directory);
+                return ! $this->filesystem->allFiles($directory);
             })
             ->each(function ($directory) {
                 $this->filesystem->deleteDirectory($directory);

--- a/src/DirectoryCleanupCommand.php
+++ b/src/DirectoryCleanupCommand.php
@@ -18,7 +18,7 @@ class DirectoryCleanupCommand extends Command
 
         collect($directories)->each(function ($config, $directory) {
             $this->deleteFilesIfOlderThanMinutes($directory, $config['deleteAllOlderThanMinutes']);
-            if (!empty($config['deleteEmptySubdirectories'])) {
+            if (! empty($config['deleteEmptySubdirectories'])) {
                 $this->deleteEmptySubdirectories($directory);
             }
         });

--- a/src/DirectoryCleanupCommand.php
+++ b/src/DirectoryCleanupCommand.php
@@ -18,6 +18,9 @@ class DirectoryCleanupCommand extends Command
 
         collect($directories)->each(function ($config, $directory) {
             $this->deleteFilesIfOlderThanMinutes($directory, $config['deleteAllOlderThanMinutes']);
+            if (!empty($config['deleteEmptySubdirectories'])) {
+                $this->deleteEmptySubdirectories($directory);
+            }
         });
 
         $this->comment('All done!');
@@ -30,5 +33,14 @@ class DirectoryCleanupCommand extends Command
             ->deleteFilesOlderThanMinutes($minutes);
 
         $this->info("Deleted {$deletedFiles->count()} file(s) from {$directory}.");
+    }
+
+    protected function deleteEmptySubdirectories(string $directory)
+    {
+        $deletedSubdirectories = app(DirectoryCleaner::class)
+            ->setDirectory($directory)
+            ->deleteEmptySubdirectories();
+
+        $this->info("Deleted {$deletedSubdirectories->count()} directory(ies) from {$directory}.");
     }
 }

--- a/tests/DirectoryCleanupTest.php
+++ b/tests/DirectoryCleanupTest.php
@@ -105,12 +105,48 @@ class DirectoryCleanupTest extends TestCase
         }
     }
 
+    /** @test */
+    public function it_can_delete_empty_subdirectories()
+    {
+        $directories[$this->getTempDirectory('keepEmptySubdirs', true)] = [
+            'deleteAllOlderThanMinutes' => 3
+        ];
+        $directories[$this->getTempDirectory('alsoKeepEmptySubdirs', true)] = [
+            'deleteAllOlderThanMinutes' => 3,
+            'deleteEmptySubdirectories' => false
+        ];
+        $directories[$this->getTempDirectory('deleteEmptySubdirs', true)] = [
+            'deleteAllOlderThanMinutes' => 3,
+            'deleteEmptySubdirectories' => true
+        ];
+
+        $this->app['config']->set('laravel-directory-cleanup', compact('directories', 'cleanup_policy'));
+
+        foreach ($directories as $directory => $config) {
+            $this->createDirectory("{$directory}/emptyDir");
+            $this->createFile("{$directory}/emptyDir/5MinutesOld.txt", 5);
+            $this->createDirectory("{$directory}/notEmptyDir");
+            $this->createFile("{$directory}/notEmptyDir/1MinutesOld.txt", 1);
+        }
+
+        $this->artisan('clean:directories');
+
+        foreach ($directories as $directory => $config) {
+            $this->assertDirectoryExists("{$directory}/notEmptyDir");
+            if (strpos($directory, 'deleteEmptySubdirs') !== false) {
+                $this->assertDirectoryNotExists("{$directory}/emptyDir");
+            } else {
+                $this->assertDirectoryExists("{$directory}/emptyDir");
+            }
+        }
+    }
+
     protected function createFile(string $fileName, int $ageInMinutes)
     {
         touch($fileName, Carbon::now()->subMinutes($ageInMinutes)->subSeconds(5)->timestamp);
     }
 
-    protected function createDirectory(string $fileName, int $ageInMinutes)
+    protected function createDirectory(string $fileName)
     {
         mkdir($fileName);
     }

--- a/tests/DirectoryCleanupTest.php
+++ b/tests/DirectoryCleanupTest.php
@@ -109,15 +109,15 @@ class DirectoryCleanupTest extends TestCase
     public function it_can_delete_empty_subdirectories()
     {
         $directories[$this->getTempDirectory('keepEmptySubdirs', true)] = [
-            'deleteAllOlderThanMinutes' => 3
+            'deleteAllOlderThanMinutes' => 3,
         ];
         $directories[$this->getTempDirectory('alsoKeepEmptySubdirs', true)] = [
             'deleteAllOlderThanMinutes' => 3,
-            'deleteEmptySubdirectories' => false
+            'deleteEmptySubdirectories' => false,
         ];
         $directories[$this->getTempDirectory('deleteEmptySubdirs', true)] = [
             'deleteAllOlderThanMinutes' => 3,
-            'deleteEmptySubdirectories' => true
+            'deleteEmptySubdirectories' => true,
         ];
 
         $this->app['config']->set('laravel-directory-cleanup', compact('directories', 'cleanup_policy'));

--- a/tests/DirectoryCleanupTest.php
+++ b/tests/DirectoryCleanupTest.php
@@ -120,7 +120,7 @@ class DirectoryCleanupTest extends TestCase
             'deleteEmptySubdirectories' => true,
         ];
 
-        $this->app['config']->set('laravel-directory-cleanup', compact('directories', 'cleanup_policy'));
+        $this->app['config']->set('laravel-directory-cleanup', compact('directories'));
 
         foreach ($directories as $directory => $config) {
             $this->createDirectory("{$directory}/emptyDir");


### PR DESCRIPTION
If after the cleaning of old files, empty subdirectories remain in the cleaned directories, delete them.