### PR TITLE
don't fail if a configured directory doesn't exist

### DIFF
--- a/src/DirectoryCleanupCommand.php
+++ b/src/DirectoryCleanupCommand.php
@@ -3,6 +3,7 @@
 namespace Spatie\DirectoryCleanup;
 
 use Illuminate\Console\Command;
+use File;
 
 class DirectoryCleanupCommand extends Command
 {
@@ -17,7 +18,9 @@ class DirectoryCleanupCommand extends Command
         $directories = collect(config('laravel-directory-cleanup.directories'));
 
         collect($directories)->each(function ($config, $directory) {
-            $this->deleteFilesIfOlderThanMinutes($directory, $config['deleteAllOlderThanMinutes']);
+            if (File::isDirectory($directory)) {
+                $this->deleteFilesIfOlderThanMinutes($directory, $config['deleteAllOlderThanMinutes']);
+            }
         });
 
         $this->comment('All done!');

--- a/src/DirectoryCleanupCommand.php
+++ b/src/DirectoryCleanupCommand.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\DirectoryCleanup;
 
-use Illuminate\Console\Command;
 use File;
+use Illuminate\Console\Command;
 
 class DirectoryCleanupCommand extends Command
 {

--- a/tests/DirectoryCleanupTest.php
+++ b/tests/DirectoryCleanupTest.php
@@ -105,6 +105,27 @@ class DirectoryCleanupTest extends TestCase
         }
     }
 
+    /** @test */
+    public function it_doesnt_fail_if_a_configured_dir_doesnt_exist()
+    {
+        $directories[$this->getTempDirectory('nodir', false)] = [
+            'deleteAllOlderThanMinutes' => 3,
+        ];
+
+        $existingDirectory = $this->getTempDirectory(1, true);
+        $directories[$existingDirectory] = [
+            'deleteAllOlderThanMinutes' => 3,
+        ];
+
+        $this->createFile("{$existingDirectory}/5MinutesOld.txt", 5);
+
+        $this->app['config']->set('laravel-directory-cleanup', compact('directories'));
+
+        $this->artisan('clean:directories');
+
+        $this->assertFileNotExists("{$existingDirectory}/5MinutesOld.txt");
+    }
+
     protected function createFile(string $fileName, int $ageInMinutes)
     {
         touch($fileName, Carbon::now()->subMinutes($ageInMinutes)->subSeconds(5)->timestamp);


### PR DESCRIPTION
I usually need to clean temp folders where temporary user files uploads are stored. For example /storage/app/public/uploads. This folder is automatically created the first time a user uploads a file. I need the command to run without errors even if this directory doesn't exist yet.