### PR TITLE
Fix for handling hidden files

### DIFF
--- a/src/DirectoryCleaner.php
+++ b/src/DirectoryCleaner.php
@@ -31,7 +31,7 @@ class DirectoryCleaner
     {
         $timeInPast = Carbon::now()->subMinutes($minutes);
 
-        return collect($this->filesystem->allFiles($this->directory))
+        return collect($this->filesystem->allFiles($this->directory, true))
             ->filter(function ($file) use ($timeInPast) {
                 return Carbon::createFromTimestamp(filemtime($file))
                     ->lt($timeInPast);
@@ -48,7 +48,7 @@ class DirectoryCleaner
     {
         return collect($this->filesystem->directories($this->directory))
             ->filter(function ($directory) {
-                return ! $this->filesystem->allFiles($directory);
+                return ! $this->filesystem->allFiles($directory, true);
             })
             ->each(function ($directory) {
                 $this->filesystem->deleteDirectory($directory);

--- a/tests/DirectoryCleanupTest.php
+++ b/tests/DirectoryCleanupTest.php
@@ -27,6 +27,7 @@ class DirectoryCleanupTest extends TestCase
         foreach ($directories as $directory => $config) {
             foreach (range(1, $numberOfDirectories) as $ageInMinutes) {
                 $this->createFile("{$directory}/{$ageInMinutes}MinutesOld.txt", $ageInMinutes);
+                $this->createFile("{$directory}/.{$ageInMinutes}MinutesOld.txt", $ageInMinutes);
             }
         }
 
@@ -36,8 +37,10 @@ class DirectoryCleanupTest extends TestCase
             foreach (range(1, $numberOfDirectories) as $ageInMinutes) {
                 if ($ageInMinutes < $config['deleteAllOlderThanMinutes']) {
                     $this->assertFileExists("{$directory}/{$ageInMinutes}MinutesOld.txt");
+                    $this->assertFileExists("{$directory}/.{$ageInMinutes}MinutesOld.txt");
                 } else {
                     $this->assertFileNotExists("{$directory}/{$ageInMinutes}MinutesOld.txt");
+                    $this->assertFileNotExists("{$directory}/.{$ageInMinutes}MinutesOld.txt");
                 }
             }
         }
@@ -59,6 +62,7 @@ class DirectoryCleanupTest extends TestCase
         foreach (range(1, $numberSubOfDirectories + 1) as $level) {
             foreach (range(1, $numberSubOfDirectories) as $ageInMinutes) {
                 $this->createFile("{$path}/{$ageInMinutes}MinutesOld.txt", $ageInMinutes);
+                $this->createFile("{$path}/.{$ageInMinutes}MinutesOld.txt", $ageInMinutes);
             }
             $path .= "{$level}/";
         }
@@ -72,8 +76,10 @@ class DirectoryCleanupTest extends TestCase
                 foreach (range(1, $numberSubOfDirectories) as $ageInMinutes) {
                     if ($ageInMinutes < $config['deleteAllOlderThanMinutes']) {
                         $this->assertFileExists("{$path}/{$ageInMinutes}MinutesOld.txt");
+                        $this->assertFileExists("{$path}/.{$ageInMinutes}MinutesOld.txt");
                     } else {
                         $this->assertFileNotExists("{$path}/{$ageInMinutes}MinutesOld.txt");
+                        $this->assertFileNotExists("{$path}/.{$ageInMinutes}MinutesOld.txt");
                     }
                 }
                 $path .= "{$level}/";
@@ -141,6 +147,10 @@ class DirectoryCleanupTest extends TestCase
             $this->createFile("{$directory}/emptyDir/5MinutesOld.txt", 5);
             $this->createDirectory("{$directory}/notEmptyDir");
             $this->createFile("{$directory}/notEmptyDir/1MinutesOld.txt", 1);
+            $this->createDirectory("{$directory}/emptyDirWithHiddenFile");
+            $this->createFile("{$directory}/emptyDirWithHiddenFile/.5MinutesOld.txt", 5);
+            $this->createDirectory("{$directory}/notEmptyDirWithHiddenFile");
+            $this->createFile("{$directory}/notEmptyDirWithHiddenFile/.1MinutesOld.txt", 1);
         }
 
         $this->artisan('clean:directories');
@@ -148,6 +158,8 @@ class DirectoryCleanupTest extends TestCase
         foreach ($directories as $directory => $config) {
             $this->assertDirectoryExists("{$directory}/notEmptyDir");
             $this->assertDirectoryNotExists("{$directory}/emptyDir");
+            $this->assertDirectoryExists("{$directory}/notEmptyDirWithHiddenFile");
+            $this->assertDirectoryNotExists("{$directory}/emptyDirWithHiddenFile");
         }
     }
 


### PR DESCRIPTION
Don't delete non-empty subdirectories that contain hidden files (#26) and delete hidden files (#27)