### PR TITLE
Fixed: set parameter minutes is wrong into method deleteFilesOlderTha…

### DIFF
--- a/src/DirectoryCleanupCommand.php
+++ b/src/DirectoryCleanupCommand.php
@@ -32,7 +32,7 @@ class DirectoryCleanupCommand extends Command
         $deletedFiles = app(DirectoryCleaner::class)
             ->setDirectory($directory)
             ->setMinutes($minutes)
-            ->deleteFilesOlderThanMinutes($minutes);
+            ->deleteFilesOlderThanMinutes();
 
         $this->info("Deleted {$deletedFiles} file(s) from {$directory}.");
     }


### PR DESCRIPTION
…nMinutes.

- Update DirectoryCleanupCommand class command, changed function deleteFilesIfOlderThanMinutes by call deleteFilesOlderThanMinutes in line 35, remove parameter $minutes.
- Developer test.