### PR TITLE
PHP 8.0.1 compatibility issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php" : "^7.2|8.0",
+        "php" : "^7.2|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
         "nesbot/carbon": "^2.0"
     },


### PR DESCRIPTION
Hi!

I think there's a trivial issue with the PHP version tag in composer that prevents using the package in PHP 8.0.1. Please take a look at the fix.

Thanks for your work!