### PR TITLE
Allow cleanup policy per each directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ php artisan vendor:publish --provider="Spatie\DirectoryCleanup\DirectoryCleanupS
 ```
 This is the content of the published config file `laravel-directory-cleanup`
 
-```
+```php
 return [
 
     'directories' => [
@@ -113,6 +113,24 @@ class MyPolicy implements CleanupPolicy
     }
 }
 ```
+
+You can use that policy per directory as well.
+
+```php
+// config/laravel-directory-cleanup.php
+return [
+    ...
+    'directories' => [
+        'path/to/a/directory' => [
+            'deleteAllOlderThanMinutes' => 60 * 24,
+            'cleanup_policy' => MyPolicy::class
+        ],
+    ]
+    ...
+];
+```
+
+If you don't have a policy defined per directory, package will use the default one.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ return [
 ];
 ```
 
-If you don't have a policy defined per directory, package will use the default one.
+If you don't have any policy defined per directory, the package will use the default one.
 
 ## Changelog
 

--- a/src/DirectoryCleanupServiceProvider.php
+++ b/src/DirectoryCleanupServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Spatie\DirectoryCleanup;
 
 use Illuminate\Support\ServiceProvider;
+use Spatie\DirectoryCleanup\Policies\CleanupPolicy;
+use Spatie\DirectoryCleanup\Policies\DeleteEverything;
 
 class DirectoryCleanupServiceProvider extends ServiceProvider
 {
@@ -18,6 +20,11 @@ class DirectoryCleanupServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/laravel-directory-cleanup.php', 'laravel-directory-cleanup');
 
         $this->app->bind('command.clean:directories', DirectoryCleanupCommand::class);
+
+        $this->app->bind(
+            CleanupPolicy::class,
+            config('laravel-directory-cleanup.cleanup_policy', DeleteEverything::class)
+        );
 
         $this->commands([
             'command.clean:directories',


### PR DESCRIPTION
This is a very useful package for sure, and I like the custom cleanup policy feature. This is just an addition to that feature, to have the possibility to set policy per each directory, since someone may want to keep some files, but only in one specific directory and not in all others.

This might be backward incompatible because of a few new arguments so I would understand if you want to wait for a new major version.

This PR also includes the replacement of deprecated PHPUnit methods "assertFileNotExists" and "assertDirectoryNotExists".

Let me know what you think about it.

Thanks!