### PR TITLE
Laravel 12 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.1, 8.0, 7.4, 7.3]
-        laravel: ['8.*', '9.*', '10.*', '11.*']
+        laravel: ['8.*', '9.*', '10.*', '11.*', '12.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -43,6 +43,8 @@ jobs:
             php: 7.4
           - laravel: 11.*
             php: 7.3
+          - laravel: 12.*
+            php: [7.3, 7.4, 8.0, 8.1]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.63" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,6 +24,8 @@ jobs:
             testbench: ^6.23
           - laravel: 11.*
             testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
         exclude:
           - laravel: 10.*
             php: 8.0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,41 +12,19 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1, 8.0, 7.4, 7.3]
-        laravel: ['8.*', '9.*', '10.*', '11.*', '12.*']
+        php: [8.1, 8.2, 8.3, 8.4]
+        laravel: ['10.*', '11.*', '12.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
-          - laravel: 9.*
-            testbench: 7.*
-          - laravel: 8.*
-            testbench: ^6.23
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
         exclude:
-          - laravel: 10.*
-            php: 8.0
-          - laravel: 10.*
-            php: 7.4
-          - laravel: 10.*
-            php: 7.3
-          - laravel: 9.*
-            php: 7.4
-          - laravel: 9.*
-            php: 7.3
           - laravel: 11.*
             php: 8.1
-          - laravel: 11.*
-            php: 8.0
-          - laravel: 11.*
-            php: 7.4
-          - laravel: 11.*
-            php: 7.3
-          - laravel: 12.*
-            php: [7.3, 7.4, 8.0, 8.1]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,6 +25,8 @@ jobs:
         exclude:
           - laravel: 11.*
             php: 8.1
+          - laravel: 12.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.1, 8.2, 8.3, 8.4]
-        laravel: ['10.*', '11.*', '12.*']
+        laravel: [10.*, 11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "nesbot/carbon": "^2.63|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5|^10.5",
+        "phpunit/phpunit": "^9.5|^10.5|^11.5",
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^8.0|^9.0|^10.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "php": "^8.1",
+        "illuminate/support": "^10.0|^11.0|^12.0",
         "nesbot/carbon": "^2.63|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5|^10.5",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0|^10.0"
+        "orchestra/testbench": "^8.0|^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "nesbot/carbon": "^2.63|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5|^10.5",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0"
+        "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request adds support for Laravel 12 and removes support for Laravel 8 and 9, as they have been EOL for over a year. Additionally, PHP 8.4 testing has been added, while support for PHP 7.3, PHP 7.4 and PHP 8.0 has been removed due to its EOL status for more than a year.